### PR TITLE
Use default dir if absent 

### DIFF
--- a/.idea/mini-ls.iml
+++ b/.idea/mini-ls.iml
@@ -4,6 +4,7 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ implement useful as a learning tool.
 
 ## Current Features and Expected Behavior (Current Implementation)
 
-| command          | outcome                                                                                |
-|------------------|----------------------------------------------------------------------------------------|
-| mini-ls ~/folder | lists all files and directories in the specified folder and prepends each with an icon |
-| mini-ls -F out.txt ~/folder | writes the contents of the specified folder out to the file out.txt |
-| mini-ls -Fout.txt ~/folder | writes the contents of the specified folder out to the file out.txt |
+| command                       | outcome                                                                                      |
+|-------------------------------|----------------------------------------------------------------------------------------------|
+| `./mini-ls ~/folder`            | lists all files and directories in the specified folder and prepends each with an icon       |
+| `./mini-ls -F out.txt ~/folder` | writes the contents of the specified folder out to the file out.txt                          |
+| `./mini-ls -Fout.txt ~/folder`  | writes the contents of the specified folder out to the file out.txt                          |
+| `./mini-ls`                     | lists all the files and directories in the folder from which it is called (works with flags) |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ implement useful as a learning tool.
 
 ## Current Features and Expected Behavior (Current Implementation)
 
-|| command          | outcome                                                                                |
+| command          | outcome                                                                                |
 |------------------|----------------------------------------------------------------------------------------|
 | mini-ls ~/folder | lists all files and directories in the specified folder and prepends each with an icon |
 | mini-ls -F out.txt ~/folder | writes the contents of the specified folder out to the file out.txt |

--- a/src/arg_processing.rs
+++ b/src/arg_processing.rs
@@ -41,13 +41,13 @@ fn parse_file_output_args(flags: &Vec<Flag>, args: &Vec<String>) -> (bool, Strin
   match f_arg {
     Some(flag) => match &flag.flag_option_text {
       Some(option_text) => (true, option_text.to_string(), flag.flag_option_index),
-      None => find_out_file(flag, args),
+      None => find_out_file_via_index(flag, args),
     },
     None => (false, "".to_string(), None),
   }
 }
 
-fn find_out_file(flag: &Flag, args: &Vec<String>) -> (bool, String, Option<usize>){
+fn find_out_file_via_index(flag: &Flag, args: &Vec<String>) -> (bool, String, Option<usize>){
   match flag.flag_option_index {
     Some(option_index) => {
       (true, match args.get(option_index) {
@@ -109,8 +109,22 @@ mod tests {
   }
 
   #[test]
-  fn target_dir_is_working_dir_if_unsupplied() {
+  fn target_dir_is_working_dir_if_unsupplied_with_concat_args() {
     let args = vec![String::from("./mini-ls"), String::from("-Flog.txt")];
+    let config = get_target(args);
+    assert_eq!(config.target, "./");
+  }
+
+  #[test]
+  fn target_dir_is_working_dir_if_unsupplied_with_args() {
+    let args = vec![String::from("./mini-ls"), String::from("-F"), String::from("log.txt")];
+    let config = get_target(args);
+    assert_eq!(config.target, "./");
+  }
+
+  #[test]
+  fn target_dir_is_working_dir_if_unsupplied_with_no_args() {
+    let args = vec![String::from("./mini-ls")];
     let config = get_target(args);
     assert_eq!(config.target, "./");
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,12 +6,18 @@ use mini_ls::arg_processing::Config;
 fn main() -> Result<(), Box<dyn Error>> {
   let args: Vec<String> = env::args().collect();
   println!("{}", args.get(0).expect("can't be missing"));
-  let config = Config::new(args);
+  let config = match Config::build(args) {
+    Ok(config) => config,
+    Err(error) => {
+      println!("Arguments are incorrect due to: {}", error);
+      process::exit(1);
+    }
+  };
   let result = manage_output(config);
   match result {
     Ok(()) => Ok(()),
     Err(error) => {
-      println!("Unable to read directory due to {}", error);
+      println!("Unable to read directory due to: {}", error);
       process::exit(1);
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use mini_ls::arg_processing::Config;
 
 fn main() -> Result<(), Box<dyn Error>> {
   let args: Vec<String> = env::args().collect();
+  println!("{}", args.get(0).expect("can't be missing"));
   let config = Config::new(args);
   let result = manage_output(config);
   match result {


### PR DESCRIPTION
Use the working directory instead of panicking when no directory argument is supplied
Add better error handling for incorrect arguments by exiting program with error code and start an enum set of error types
