### PR TITLE
Extended attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dirs = "5.0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 dirs = "5.0.1"
+term_size = "0.3.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2021"
 dirs = "5.0.1"
 term_size = "0.3.2"
 chrono = "0.4.31"
+unicode-segmentation = "1.10.1"
 
 [dev-dependencies]
+filepath = "0.1.2"
 tempfile = "3"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 dirs = "5.0.1"
 term_size = "0.3.2"
+chrono = "0.4.31"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ implement useful as a learning tool.
 | `./mini-ls -F out.txt ~/folder` | writes the contents of the specified folder out to the file out.txt                          |
 | `./mini-ls -Fout.txt ~/folder`  | writes the contents of the specified folder out to the file out.txt                          |
 | `./mini-ls`                     | lists all the files and directories in the folder from which it is called (works with flags) |
+ | `./mini-ls -l` | includes file metadata about the date created, date modified and whether it is writeable or not |

--- a/src/arg_processing.rs
+++ b/src/arg_processing.rs
@@ -111,12 +111,13 @@ fn process_single_flag(
     index: usize,
     discovered_options: &mut Vec<usize>,
 ) -> Result<Vec<Argument>, ArgParsingError> {
-    let switch = extract_single_no_concat_switch(string)?;
-    let requires_option = requires_option(&switch);
-    if requires_option && index <= arg_length - 2 {
-        discovered_options.push(index + 1);
+    let argument = extract_single_no_concat_switch(string)?;
+    if let Argument::Flag { switch, .. } = &argument {
+        if AllowedFlags::requires_option(switch) && index <= arg_length - 2 {
+            discovered_options.push(index + 1);
+        }
     }
-    Ok::<Vec<Argument>, ArgParsingError>(vec![switch])
+    Ok::<Vec<Argument>, ArgParsingError>(vec![argument])
 }
 
 fn extract_single_no_concat_switch(string: &str) -> Result<Argument, ArgParsingError> {
@@ -135,13 +136,6 @@ fn extract_single_no_concat_switch(string: &str) -> Result<Argument, ArgParsingE
         argument => Err(ArgParsingError::UnexpectedArgument {
             argument: argument.to_string(),
         }),
-    }
-}
-
-fn requires_option(switch: &Argument) -> bool {
-    match switch {
-        Argument::Flag { switch, .. } => AllowedFlags::requires_option(switch),
-        _ => false,
     }
 }
 

--- a/src/arg_processing.rs
+++ b/src/arg_processing.rs
@@ -3,140 +3,192 @@ use std::fmt::Formatter;
 use std::path::Path;
 
 pub struct Config {
-  pub target: String,
-  pub to_file: bool,
-  pub target_file: String,
+    pub target: String,
+    pub to_file: bool,
+    pub target_file: String,
 }
 
 struct Flag {
-  text: String,
-  flag_option_index: Option<usize>,
-  flag_option_text: Option<String>,
+    text: String,
+    flag_option_index: Option<usize>,
+    flag_option_text: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub enum ArgParsingError{
-  MissingFileOption
+pub enum ArgParsingError {
+    MissingFileOption,
 }
 
 impl fmt::Display for ArgParsingError {
-  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-    write!(f, "missing file argument for -F flag")
-  }
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "missing file argument for -F flag")
+    }
 }
 
 impl Config {
-  pub fn build(args: Vec<String>) -> Result<Config, ArgParsingError> {
-    let flags: Vec<Flag> = parse_flags(&args);
-    let (to_file, target_file, option_index) = parse_file_output_args(&flags, &args)?;
-    let target = if args.len() == 1 || option_index.is_some_and(|i| i == args.len() - 1) || (option_index.is_none() && to_file && args.len() == 2) {
-      "./".to_string()
-    } else {
-      args.last().expect("Already checked there are args").to_string()
+    pub fn build(args: Vec<String>) -> Result<Config, ArgParsingError> {
+        let flags: Vec<Flag> = parse_flags(&args);
+        let (to_file, target_file, option_index) = parse_file_output_args(&flags, &args)?;
+        let target = if args.len() == 1
+            || option_index.is_some_and(|i| i == args.len() - 1)
+            || (option_index.is_none() && to_file && args.len() == 2)
+        {
+            "./".to_string()
+        } else {
+            args.last()
+                .expect("Already checked there are args")
+                .to_string()
+        };
+        Ok(Config {
+            target,
+            to_file,
+            target_file,
+        })
+    }
+}
+
+fn parse_flags(args: &[String]) -> Vec<Flag> {
+    let flag_mapper = |(i, arg): (usize, &String)| {
+        let flag_option_index = if arg.len() > 2 { None } else { Some(i + 1) };
+        let flag_option_text = if arg.len() > 2 {
+            Some(arg[2..].to_string())
+        } else {
+            None
+        };
+        Flag {
+            text: arg.to_string().replace('-', ""),
+            flag_option_index,
+            flag_option_text,
+        }
     };
-    Ok(Config { target, to_file, target_file })
-  }
+    args.iter()
+        .enumerate()
+        .filter(|(i, arg)| *i != 0 && arg.starts_with('-'))
+        .map(flag_mapper)
+        .collect()
 }
 
-fn parse_flags(args: &Vec<String>) -> Vec<Flag> {
-  let flag_mapper = |(i, arg): (usize, &String)| {
-    let flag_option_index = if arg.len() > 2 {None } else {Some(i + 1)};
-    let flag_option_text = if arg.len() > 2 { Some(arg[2..].to_string())} else {None};
-    Flag { text: arg.to_string().replace("-", ""), flag_option_index, flag_option_text }};
-  args.iter().enumerate()
-    .filter(|(i, arg)| *i != 0 && arg.starts_with("-"))
-    .map(flag_mapper)
-    .collect()
+fn parse_file_output_args(
+    flags: &[Flag],
+    args: &[String],
+) -> Result<(bool, String, Option<usize>), ArgParsingError> {
+    let f_arg = flags.iter().find(|flag| flag.text.starts_with('F'));
+    match f_arg {
+        Some(flag) => match &flag.flag_option_text {
+            Some(option_text) => Ok((true, option_text.to_string(), flag.flag_option_index)),
+            None => find_out_file_via_index(flag, args),
+        },
+        None => Ok((false, "".to_string(), None)),
+    }
 }
 
-fn parse_file_output_args(flags: &Vec<Flag>, args: &Vec<String>) -> Result<(bool, String, Option<usize>), ArgParsingError> {
-  let f_arg = flags.iter().find(|flag| flag.text.starts_with("F"));
-  match f_arg {
-    Some(flag) => match &flag.flag_option_text {
-      Some(option_text) => Ok((true, option_text.to_string(), flag.flag_option_index)),
-      None => find_out_file_via_index(flag, args),
-    },
-    None => Ok((false, "".to_string(), None)),
-  }
-}
-
-fn find_out_file_via_index(flag: &Flag, args: &Vec<String>) -> Result<(bool, String, Option<usize>), ArgParsingError>{
-  match flag.flag_option_index {
-    Some(option_index) => {
-      Ok((true, match args.get(option_index) {
-        Some(option_text) => {
-          if Path::new(option_text).is_dir() {
-            return Err(ArgParsingError::MissingFileOption);
-          }
-          option_text.to_string()},
-        None => {return Err(ArgParsingError::MissingFileOption);}
-      }, flag.flag_option_index))
-    },
-    _ => Ok((false, "".to_string(), None))
-  }
+fn find_out_file_via_index(
+    flag: &Flag,
+    args: &[String],
+) -> Result<(bool, String, Option<usize>), ArgParsingError> {
+    match flag.flag_option_index {
+        Some(option_index) => Ok((
+            true,
+            match args.get(option_index) {
+                Some(option_text) => {
+                    if Path::new(option_text).is_dir() {
+                        return Err(ArgParsingError::MissingFileOption);
+                    }
+                    option_text.to_string()
+                }
+                None => {
+                    return Err(ArgParsingError::MissingFileOption);
+                }
+            },
+            flag.flag_option_index,
+        )),
+        _ => Ok((false, "".to_string(), None)),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-  use super::Config;
+    use super::Config;
 
-  #[test]
-  fn obtains_the_dir_from_args() {
-    let args = vec![String::from("./mini-ls"), String::from("~/dev"), ];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "~/dev");
-  }
+    #[test]
+    fn obtains_the_dir_from_args() {
+        let args = vec![String::from("./mini-ls"), String::from("~/dev")];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "~/dev");
+    }
 
-  #[test]
-  fn extracts_f_arg_to_config() {
-    let args = vec![String::from("./mini-ls"), String::from("-F"), String::from("log.txt"), String::from("~/dev")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.to_file, true);
-  }
+    #[test]
+    fn extracts_f_arg_to_config() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-F"),
+            String::from("log.txt"),
+            String::from("~/dev"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert!(config.to_file);
+    }
 
-  #[test]
-  fn extracts_target_dir_when_f_arg() {
-    let args = vec![String::from("./mini-ls"), String::from("-F"), String::from("log.txt"), String::from("~/dev")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "~/dev");
-  }
+    #[test]
+    fn extracts_target_dir_when_f_arg() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-F"),
+            String::from("log.txt"),
+            String::from("~/dev"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "~/dev");
+    }
 
-  #[test]
-  fn returns_an_error_if_missing_file_for_output_with_f_flag() {
-    let args = vec![String::from("./mini-ls"), String::from("-F"), String::from("/dev")];
-    let _config = Config::build(args);
-    assert!(_config.is_err());
-    let error = _config.err().unwrap();
-    assert_eq!(error.to_string(), "missing file argument for -F flag")
-  }
+    #[test]
+    fn returns_an_error_if_missing_file_for_output_with_f_flag() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-F"),
+            String::from("/dev"),
+        ];
+        let _config = Config::build(args);
+        assert!(_config.is_err());
+        let error = _config.err().unwrap();
+        assert_eq!(error.to_string(), "missing file argument for -F flag")
+    }
 
-  #[test]
-  fn accepts_flags_concatenated_with_options() {
-    let args = vec![String::from("./mini-ls"), String::from("-Flog.txt"), String::from("~/dev")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "~/dev");
-    assert!(config.to_file);
-    assert_eq!(config.target_file, "log.txt");
-  }
+    #[test]
+    fn accepts_flags_concatenated_with_options() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-Flog.txt"),
+            String::from("~/dev"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "~/dev");
+        assert!(config.to_file);
+        assert_eq!(config.target_file, "log.txt");
+    }
 
-  #[test]
-  fn target_dir_is_working_dir_if_unsupplied_with_concat_args() {
-    let args = vec![String::from("./mini-ls"), String::from("-Flog.txt")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "./");
-  }
+    #[test]
+    fn target_dir_is_working_dir_if_un_supplied_with_concat_args() {
+        let args = vec![String::from("./mini-ls"), String::from("-Flog.txt")];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "./");
+    }
 
-  #[test]
-  fn target_dir_is_working_dir_if_unsupplied_with_args() {
-    let args = vec![String::from("./mini-ls"), String::from("-F"), String::from("log.txt")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "./");
-  }
+    #[test]
+    fn target_dir_is_working_dir_if_un_supplied_with_args() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-F"),
+            String::from("log.txt"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "./");
+    }
 
-  #[test]
-  fn target_dir_is_working_dir_if_unsupplied_with_no_args() {
-    let args = vec![String::from("./mini-ls")];
-    let config = Config::build(args).unwrap();
-    assert_eq!(config.target, "./");
-  }
+    #[test]
+    fn target_dir_is_working_dir_if_un_supplied_with_no_args() {
+        let args = vec![String::from("./mini-ls")];
+        let config = Config::build(args).unwrap();
+        assert_eq!(config.target, "./");
+    }
 }

--- a/src/arg_processing.rs
+++ b/src/arg_processing.rs
@@ -274,6 +274,7 @@ fn parse_extended_attribute_flag(flags: &[Argument]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::Config;
+    use std::env::temp_dir;
 
     #[test]
     fn obtains_the_dir_from_args() {
@@ -308,10 +309,13 @@ mod tests {
 
     #[test]
     fn returns_an_error_if_missing_file_for_output_with_f_flag() {
+        let temp_dir = temp_dir();
+        let temp_dir_path = temp_dir.to_path_buf();
+        let temp_path = temp_dir_path.to_str().unwrap();
         let args = vec![
             String::from("./mini-ls"),
             String::from("-F"),
-            String::from("~/dev"),
+            String::from(temp_path),
         ];
         let config = Config::build(args);
         assert!(config.is_err());

--- a/src/arg_processing.rs
+++ b/src/arg_processing.rs
@@ -376,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    fn finds_all_flags() {
+    fn finds_all_flags_and_options() {
         let args = vec![
             String::from("./mini-ls"),
             String::from("-lF"),
@@ -386,6 +386,36 @@ mod tests {
         assert!(config.extended_attributes);
         assert!(config.to_file);
         assert_eq!(config.target_file, "log.txt");
+    }
+
+    #[test]
+    fn finds_all_flags_options_when_separated() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-l"),
+            String::from("-F"),
+            String::from("log.txt"),
+            String::from("/opt/dev"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert!(config.extended_attributes);
+        assert!(config.to_file);
+        assert_eq!(config.target_file, "log.txt");
+        assert_eq!(config.target, "/opt/dev");
+    }
+
+    #[test]
+    fn still_extracts_all_flags_in_concat_block() {
+        let args = vec![
+            String::from("./mini-ls"),
+            String::from("-lFlog.txt"),
+            String::from("/opt/dev"),
+        ];
+        let config = Config::build(args).unwrap();
+        assert!(config.to_file);
+        assert!(config.extended_attributes);
+        assert_eq!(config.target_file, "log.txt");
+        assert_eq!(config.target, "/opt/dev");
     }
 
     //duplicate options generated where multiple flags with options in block (NYI)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod arg_processing;
 
+use crate::arg_processing::Config;
 use std::fs;
 use std::fs::{DirEntry, ReadDir};
 use std::path::Path;
-use crate::arg_processing::Config;
 
 const FLOPPY: &str = "\u{1F4BE}";
 const FOLDER: &str = "\u{1F4C1}";
@@ -14,14 +14,16 @@ fn list_contents(directory: &str) -> Result<String, std::io::Error> {
         Ok(file_collection) => Ok(convert_read_dir_to_filename_collection(file_collection)),
         Err(error) => {
             eprintln!("was unable to read the contents of {}", directory);
-            Err(error)}
+            Err(error)
+        }
     }
 }
 
 fn convert_read_dir_to_filename_collection(file_collection: ReadDir) -> String {
-    let (directories, files): (Vec<DirEntry>, Vec<DirEntry>) = file_collection.into_iter()
-      .filter_map(|dir_entry| dir_entry.ok())
-      .partition(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()));
+    let (directories, files): (Vec<DirEntry>, Vec<DirEntry>) = file_collection
+        .into_iter()
+        .filter_map(|dir_entry| dir_entry.ok())
+        .partition(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()));
     let mut string_list_of_files = prepend_each_entry(files, FLOPPY);
     let mut string_list_of_dirs = prepend_each_entry(directories, FOLDER);
     string_list_of_files.append(&mut string_list_of_dirs);
@@ -29,10 +31,11 @@ fn convert_read_dir_to_filename_collection(file_collection: ReadDir) -> String {
 }
 
 fn prepend_each_entry(dir_entries: Vec<DirEntry>, icon: &str) -> Vec<String> {
-    dir_entries.into_iter()
-      .map(convert_dir_entry_to_str)
-      .map(|file_name| icon.to_owned() + " " + &*file_name)
-      .collect()
+    dir_entries
+        .into_iter()
+        .map(convert_dir_entry_to_str)
+        .map(|file_name| icon.to_owned() + " " + &*file_name)
+        .collect()
 }
 
 fn convert_dir_entry_to_str(dir_entry: DirEntry) -> String {
@@ -50,13 +53,12 @@ pub fn manage_output(config: Config) -> std::io::Result<()> {
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use tempfile::*;
-    use std::fs::File;
     use super::*;
+    use std::fs;
+    use std::fs::File;
+    use tempfile::*;
 
     const FILE_1_NAME: &str = "file_1.txt";
     const FILE_2_NAME: &str = "file_2.txt";
@@ -87,26 +89,42 @@ mod tests {
     fn includes_that_the_entry_is_a_file() {
         let temp_dir = setup_basic_test();
         let list_of_contents = list_contents(temp_dir.path().to_str().unwrap());
-        assert_eq!(list_of_contents.unwrap().lines().filter(|line| line.starts_with(FLOPPY_ICON)).count(), 2);
+        assert_eq!(
+            list_of_contents
+                .unwrap()
+                .lines()
+                .filter(|line| line.starts_with(FLOPPY_ICON))
+                .count(),
+            2
+        );
     }
 
     #[test]
     fn includes_folder_icon_for_sub_folders() {
         let temp_dir = setup_basic_test();
-        let folder_2 = temp_dir.path().join("subfolder");
-        fs::create_dir(folder_2.as_path().to_owned()).unwrap();
+        let folder_2 = temp_dir.path().join("sub_folder");
+        fs::create_dir(folder_2.as_path()).unwrap();
         assert!(folder_2.exists());
         let list_of_contents = list_contents(temp_dir.path().to_str().unwrap());
-        assert_eq!(list_of_contents.unwrap().lines().filter(|line| line.starts_with(FOLDER_ICON)).count(), 1);
+        assert_eq!(
+            list_of_contents
+                .unwrap()
+                .lines()
+                .filter(|line| line.starts_with(FOLDER_ICON))
+                .count(),
+            1
+        );
     }
 
     #[test]
     fn writes_to_file() {
         let temp_dir = setup_basic_test();
         let file_1 = temp_dir.path().join("log.txt");
-        let config = Config{target: temp_dir.path().to_str().unwrap().to_string(),
+        let config = Config {
+            target: temp_dir.path().to_str().unwrap().to_string(),
             to_file: true,
-            target_file: file_1.to_str().unwrap().to_string()};
+            target_file: file_1.to_str().unwrap().to_string(),
+        };
         manage_output(config).unwrap();
         assert!(file_1.exists());
         let file_content = fs::read_to_string(file_1.as_path()).unwrap();
@@ -121,10 +139,9 @@ mod tests {
         let config = Config {
             target: target.as_path().to_str().unwrap().to_string(),
             to_file: false,
-            target_file: "".to_string()
+            target_file: "".to_string(),
         };
         let contents = list_contents(config.target.as_str());
         assert!(contents.is_err());
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ mod tests {
             target: temp_dir.path().to_str().unwrap().to_string(),
             to_file: true,
             target_file: file_1.to_str().unwrap().to_string(),
+            extended_attributes: false,
         };
         manage_output(config).unwrap();
         assert!(file_1.exists());
@@ -140,6 +141,7 @@ mod tests {
             target: target.as_path().to_str().unwrap().to_string(),
             to_file: false,
             target_file: "".to_string(),
+            extended_attributes: false,
         };
         let contents = list_contents(config.target.as_str());
         assert!(contents.is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::ops::Add;
 use std::path::Path;
 use std::time::{Duration, UNIX_EPOCH};
 use std::{fmt, fs, io};
+use unicode_segmentation::UnicodeSegmentation;
 
 const FLOPPY: &str = "\u{1F4BE}";
 const FOLDER: &str = "\u{1F4C1}";
@@ -102,7 +103,8 @@ fn convert_read_dir_to_filename_collection(
     };
 
     let mut string_list_of_files = if extended_attr && width > 80 {
-        format_each_ext_attr_entry(&files)?
+        let file_name_max_length = width - 63;
+        format_each_ext_attr_entry(&files, file_name_max_length)?
     } else {
         format_each_entry(files, FLOPPY)?
     };
@@ -141,14 +143,23 @@ fn create_heading_of_width(head_width: usize, name: &str) -> String {
         .add(" ".repeat(head_width - name.len()).as_str())
 }
 
-fn format_each_ext_attr_entry(files: &[DirEntry]) -> Result<Vec<String>, FileEntryParsingError> {
-    files.iter().map(format_file_entry_with_ext_attr).collect()
+fn format_each_ext_attr_entry(
+    files: &[DirEntry],
+    max_file_name_width: usize,
+) -> Result<Vec<String>, FileEntryParsingError> {
+    files
+        .iter()
+        .map(|dir| format_file_entry_with_ext_attr(dir, max_file_name_width))
+        .collect()
 }
 
-fn format_file_entry_with_ext_attr(dir: &DirEntry) -> Result<String, FileEntryParsingError> {
+fn format_file_entry_with_ext_attr(
+    dir: &DirEntry,
+    allowed_width: usize,
+) -> Result<String, FileEntryParsingError> {
     let file_name_as_path = dir.path();
     let file_name = match file_name_as_path.to_str() {
-        Some(file_name) => file_name,
+        Some(file_name) => limit_filename_length(allowed_width, file_name),
         None => return Err(FileEntryParsingError::FileNameInvalidUnicode),
     };
     let meta_data = match dir.metadata() {
@@ -168,12 +179,24 @@ fn format_file_entry_with_ext_attr(dir: &DirEntry) -> Result<String, FileEntryPa
     let date_modified = get_formatted_date(&meta_data, Modified);
     Ok([
         FLOPPY,
-        file_name,
+        file_name.as_str(),
         &date_created,
         permissions,
         &date_modified,
     ]
     .join(" "))
+}
+
+fn limit_filename_length(allowed_width: usize, file_name: &str) -> String {
+    if file_name.graphemes(true).count() >= allowed_width {
+        let file_name_strs = file_name
+            .graphemes(true)
+            .take(allowed_width)
+            .collect::<Vec<&str>>();
+        file_name_strs.join("")
+    } else {
+        file_name.to_string()
+    }
 }
 
 fn get_formatted_date(meta_data: &Metadata, options: TimeOptions) -> String {
@@ -241,11 +264,13 @@ pub fn manage_output(config: Config) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use chrono::{DateTime, Utc};
+    use filepath::FilePath;
     use std::fs::File;
     use std::io::Write;
     use std::time::SystemTime;
     use std::{fs, thread, time};
     use tempfile::*;
+    use unicode_segmentation::UnicodeSegmentation;
 
     const FILE_1_NAME: &str = "file_1.txt";
     const FILE_2_NAME: &str = "file_2.txt";
@@ -474,9 +499,64 @@ mod tests {
         assert!(!contents.contains("Permissions"));
     }
 
-    //rows do not contain extended attributes when false
-    //long file names are shortened for small widths to maintain extended attributes
+    #[test]
+    fn does_not_contain_extended_attributes_when_not_set() {
+        let (temp_dir, file_1, _file_2) = setup_basic_test();
+        let config = Config {
+            target: temp_dir.path().to_str().unwrap().to_string(),
+            to_file: false,
+            target_file: "".to_string(),
+            extended_attributes: false,
+        };
+        let contents = list_contents(&config, 400).unwrap();
+        let lines_of_content: Vec<&str> = contents.split('\n').collect();
+        let first_file_line = lines_of_content.get(2).unwrap();
+        let components: Vec<&str> = first_file_line.split_ascii_whitespace().collect();
+        assert_eq!(2, components.len());
+    }
+
+    #[test]
+    fn file_names_shortened_for_small_terminals_when_ext_attr_set() {
+        let long_file_name =
+            "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(long_file_name);
+        let file_2 = temp_dir.path().join(FILE_2_NAME);
+        let file_1_as_file = File::create(&file_1).unwrap();
+        let file_2_as_file = File::create(&file_2).unwrap();
+        assert!(file_1.as_path().exists());
+        assert!(file_2.as_path().exists());
+        let config = Config {
+            target: temp_dir.path().to_str().unwrap().to_string(),
+            to_file: false,
+            target_file: "".to_string(),
+            extended_attributes: true,
+        };
+        let current_reserved_length = 63;
+        let file_1_full_path = file_1.to_str().unwrap();
+        let compressed_width = file_1_full_path.graphemes(true).count(); //so always file path is smaller that console
+        let contents = list_contents(&config, compressed_width).unwrap();
+        let lines_of_content: Vec<&str> = contents.split('\n').collect();
+        let first_file_line = lines_of_content.get(2).unwrap();
+        let second_file_line = lines_of_content.get(3).unwrap();
+        let target_line = if first_file_line.contains("very_long") {
+            first_file_line
+        } else {
+            second_file_line
+        };
+        println!("{}", target_line);
+        assert_eq!(target_line.len(), compressed_width);
+        assert!(!target_line.contains(file_1_full_path));
+        let expected_content_chars: Vec<&str> = file_1_full_path
+            .graphemes(true)
+            .take(compressed_width - current_reserved_length)
+            .collect();
+        let expected_content = expected_content_chars.join("");
+        assert!(target_line.contains(&expected_content));
+    }
+
     //spaces inserted between fields match intended widths of each column
     //all fields end with one space even if overflowed
     // returns an error when the console width is too small for extended attributes
+    // limit filename length even without extended attributes but to total width
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,14 +130,13 @@ pub fn manage_output(config: Config) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output_formatting::{DATE_FORMAT, RESERVED_LENGTH};
+    use crate::output_formatting::DATE_FORMAT;
     use chrono::{DateTime, Utc};
     use std::fs::File;
     use std::io::Write;
     use std::time::SystemTime;
     use std::{fs, thread, time};
     use tempfile::*;
-    use unicode_segmentation::UnicodeSegmentation;
 
     const FILE_1_NAME: &str = "file_1.txt";
     const FILE_2_NAME: &str = "file_2.txt";
@@ -222,23 +221,6 @@ mod tests {
     }
 
     #[test]
-    fn spaces_out_columns() {
-        let (temp_dir, ..) = setup_basic_test();
-        let config = Config {
-            target: temp_dir.path().to_str().unwrap().to_string(),
-            to_file: false,
-            target_file: "".to_string(),
-            extended_attributes: true,
-        };
-        // Date Created and Date Modified = 24 each, rest Name
-        let expected_header = "Name                                    Date Created            Permissions  Date Modified           ";
-        let contents = list_contents(&config, 100).unwrap();
-        let lines_of_content: Vec<&str> = contents.split('\n').collect();
-        let header = lines_of_content[0];
-        assert_eq!(expected_header, header);
-    }
-
-    #[test]
     fn contains_date_created_attr() {
         let (temp_dir, file_1, _file_2) = setup_basic_test();
         let expected_file_1_created = file_1.metadata().unwrap().created().unwrap();
@@ -271,6 +253,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "linux"))]
     fn contains_permissions_when_extended_attr() {
         let (temp_dir, file_1, _file_2) = setup_basic_test();
         let mut permissions = file_1.metadata().unwrap().permissions();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,17 +72,6 @@ impl From<FileEntryParsingError> for io::Error {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum ConsoleFormattingError {
-    InadequateConsoleWidth,
-}
-
-impl fmt::Display for ConsoleFormattingError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "requires minimum width of 80")
-    }
-}
-
 fn list_contents(config: &Config, width: usize) -> Result<String, FileEntryParsingError> {
     let dir_read = fs::read_dir(&config.target);
     match dir_read {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,15 +111,6 @@ fn split_into_files_and_dirs(file_collection: ReadDir) -> (Vec<DirEntry>, Vec<Di
         .partition(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
 }
 
-fn convert_dir_entry_to_str(dir_entry: &DirEntry) -> Result<String, FileEntryParsingError> {
-    let file_name = dir_entry.file_name();
-    let normal_str = match file_name.to_str() {
-        Some(name) => name,
-        None => return Err(FileEntryParsingError::FileNameInvalidUnicode),
-    };
-    Ok(String::from(normal_str))
-}
-
 pub fn manage_output(config: Config) -> std::io::Result<()> {
     let width = if !config.to_file {
         term_size::dimensions()
@@ -151,7 +142,6 @@ mod tests {
     const FILE_1_NAME: &str = "file_1.txt";
     const FILE_2_NAME: &str = "file_2.txt";
     const FLOPPY_ICON: &str = "\u{1F4BE}";
-    const FOLDER_ICON: &str = "\u{1F4C1}";
 
     fn setup_basic_test() -> (TempDir, File, File) {
         let temp_dir = tempdir().unwrap();
@@ -197,24 +187,6 @@ mod tests {
                 .filter(|line| line.starts_with(FLOPPY_ICON))
                 .count(),
             2
-        );
-    }
-
-    #[test]
-    fn includes_folder_icon_for_sub_folders() {
-        let (temp_dir, ..) = setup_basic_test();
-        let folder_2 = temp_dir.path().join("sub_folder");
-        fs::create_dir(folder_2.as_path()).unwrap();
-        assert!(folder_2.exists());
-        let (config, _temp_dir) = get_typical_config(Some(temp_dir));
-        let list_of_contents = list_contents(&config, 100);
-        assert_eq!(
-            list_of_contents
-                .unwrap()
-                .lines()
-                .filter(|line| line.starts_with(FOLDER_ICON))
-                .count(),
-            1
         );
     }
 

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -1,0 +1,57 @@
+use crate::{FileEntryParsingError, FLOPPY, FOLDER, RESERVED_LENGTH};
+use std::fs::DirEntry;
+
+pub struct FormattingCommand {
+    extended_attr: bool,
+    width: usize,
+    files: Vec<DirEntry>,
+    longest: usize,
+}
+
+impl FormattingCommand {
+    pub fn new(extended_attr: bool, width: usize, files: Vec<DirEntry>, longest: usize) -> Self {
+        FormattingCommand {
+            extended_attr,
+            width,
+            files,
+            longest,
+        }
+    }
+}
+
+pub fn generate_textual_display(
+    command: FormattingCommand,
+    directories: Vec<DirEntry>,
+) -> Result<String, FileEntryParsingError> {
+    let mut header_row = if command.extended_attr && command.width > 80 {
+        crate::create_extended_attr_header(command.width, command.longest)
+    } else {
+        vec![
+            String::from("Name:"),
+            String::from("=").repeat(command.width),
+        ]
+    };
+    let mut string_list_of_files = orchestrate_formatting(command)?;
+    let mut string_list_of_dirs = crate::format_each_entry(directories, FOLDER)?;
+    header_row.append(&mut string_list_of_files);
+    header_row.append(&mut string_list_of_dirs);
+    Ok(header_row.join("\n"))
+}
+
+fn orchestrate_formatting(
+    command: FormattingCommand,
+) -> Result<Vec<String>, FileEntryParsingError> {
+    Ok(if command.extended_attr && command.width > 80 {
+        let available_filename_space = command.width - RESERVED_LENGTH;
+        let file_name_target_length = if available_filename_space > command.longest {
+            command.longest
+        } else {
+            available_filename_space
+        };
+        crate::format_each_ext_attr_entry(&command.files, file_name_target_length)?
+    } else if command.extended_attr && command.width <= 80 {
+        panic!("requires minimum console width of 80");
+    } else {
+        crate::format_each_entry(command.files, FLOPPY)?
+    })
+}

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -231,8 +231,6 @@ fn convert_dir_entry_to_str(dir_entry: &DirEntry) -> Result<String, FileEntryPar
 
 #[cfg(test)]
 mod tests {
-    use crate::arg_processing::Config;
-    use crate::list_contents;
     use crate::output_formatting::{
         generate_textual_display, FormattingCommand, FOLDER, RESERVED_LENGTH,
     };
@@ -452,7 +450,6 @@ mod tests {
             .filter_map(|entry| entry.ok())
             .partition(|entry| entry.metadata().unwrap().is_file());
         let file_2_full_path = file_2.to_str().unwrap().to_string();
-        let compressed_width = file_2_full_path.graphemes(true).count(); //so always file path is smaller that console
         let max_name_width = file_2_full_path.graphemes(true).count();
         let always_sufficient_length = max_name_width + 70; //so always file path is smaller that console
         let command = FormattingCommand::new(true, always_sufficient_length, files, directories);
@@ -480,5 +477,17 @@ mod tests {
             file_2_parts[0].graphemes(true).count(),
             file_1_parts[0].graphemes(true).count()
         );
+    }
+
+    #[test]
+    fn spaces_out_columns() {
+        let (_tempdir, file_entries, directories) = setup_test();
+        let command = FormattingCommand::new(true, 100, file_entries, directories);
+        let contents = generate_textual_display(command).unwrap();
+        // Date Created and Date Modified = 24 each, rest Name
+        let expected_header = "Name                                    Date Created            Permissions  Date Modified           ";
+        let lines_of_content: Vec<&str> = contents.split('\n').collect();
+        let header = lines_of_content[0];
+        assert_eq!(expected_header, header);
     }
 }

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -40,21 +40,19 @@ impl FormattingCommand {
 pub fn generate_textual_display(
     command: FormattingCommand,
 ) -> Result<String, FileEntryParsingError> {
-    let boxed_command = Rc::new(command);
-    let command_ref = boxed_command.as_ref();
-    let Some(longest) = analyse_longest(boxed_command.as_ref()) else {
+    let Some(longest) = analyse_longest(&command) else {
         return Err(UnableToCalculatePathLengths);
     };
-    let mut header_row = if command_ref.extended_attr && command_ref.width > 80 {
-        create_extended_attr_header(command_ref.width, longest)
+    let mut header_row = if command.extended_attr && command.width > 80 {
+        create_extended_attr_header(command.width, longest)
     } else {
         vec![
             String::from("Name:"),
-            String::from("=").repeat(command_ref.width),
+            String::from("=").repeat(command.width),
         ]
     };
-    let mut string_list_of_files = orchestrate_formatting(boxed_command.as_ref(), longest)?;
-    let mut string_list_of_dirs = format_each_entry(&command_ref.directories, FOLDER)?;
+    let mut string_list_of_files = orchestrate_formatting(&command, longest)?;
+    let mut string_list_of_dirs = format_each_entry(&command.directories, FOLDER)?;
     header_row.append(&mut string_list_of_files);
     header_row.append(&mut string_list_of_dirs);
     Ok(header_row.join("\n"))
@@ -213,7 +211,7 @@ fn format_date(since_epoch: Duration) -> String {
 }
 
 fn format_each_entry(
-    dir_entries: &Vec<DirEntry>,
+    dir_entries: &[DirEntry],
     icon: &str,
 ) -> Result<Vec<String>, FileEntryParsingError> {
     Ok(dir_entries
@@ -234,15 +232,21 @@ fn convert_dir_entry_to_str(dir_entry: &DirEntry) -> Result<String, FileEntryPar
 
 #[cfg(test)]
 mod tests {
-    use crate::output_formatting::{generate_textual_display, FormattingCommand, FOLDER};
+    use crate::arg_processing::Config;
+    use crate::list_contents;
+    use crate::output_formatting::{
+        generate_textual_display, FormattingCommand, FOLDER, RESERVED_LENGTH,
+    };
+    use crate::tests::calc_expected_date_string;
     use std::fs;
     use std::fs::{DirEntry, File};
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
+    use unicode_segmentation::UnicodeSegmentation;
 
-    fn setup_test() -> (Vec<DirEntry>, Vec<DirEntry>) {
-        const FILE_1_NAME: &str = "file_1.txt";
-        const FILE_2_NAME: &str = "file_2.txt";
+    const FILE_1_NAME: &str = "file_1.txt";
+    const FILE_2_NAME: &str = "file_2.txt";
 
+    fn setup_test() -> (TempDir, Vec<DirEntry>, Vec<DirEntry>) {
         let temp_dir = tempdir().unwrap();
         let file_1 = temp_dir.path().join(FILE_1_NAME);
         let file_2 = temp_dir.path().join(FILE_2_NAME);
@@ -251,15 +255,15 @@ mod tests {
         File::create(&file_2).unwrap();
         fs::create_dir(&extra_dir).unwrap();
         let dir_read = fs::read_dir(temp_dir.path()).unwrap();
-
-        dir_read
+        let (files, directories) = dir_read
             .filter_map(|entry| entry.ok())
-            .partition(|entry| entry.metadata().unwrap().is_file())
+            .partition(|entry| entry.metadata().unwrap().is_file());
+        (temp_dir, files, directories)
     }
 
     #[test]
     fn non_extended_output_contains_header_row() {
-        let (file_entries, directories) = setup_test();
+        let (_tempdir, file_entries, directories) = setup_test();
         let command = FormattingCommand::new(false, 200, file_entries, directories);
         let content = generate_textual_display(command).unwrap();
         let lines_of_content = content.split('\n').collect::<Vec<&str>>();
@@ -272,7 +276,7 @@ mod tests {
 
     #[test]
     fn includes_folder_icon_for_sub_folders() {
-        let (file_entries, directories) = setup_test();
+        let (_tempdir, file_entries, directories) = setup_test();
         let command = FormattingCommand::new(false, 100, file_entries, directories);
         let content = generate_textual_display(command).unwrap();
         assert_eq!(
@@ -281,6 +285,201 @@ mod tests {
                 .filter(|line| line.starts_with(FOLDER))
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn contains_seperator_row() {
+        let (_tempdir, file_entries, directories) = setup_test();
+        let command = FormattingCommand::new(false, 100, file_entries, directories);
+        let content = generate_textual_display(command).unwrap();
+        let expected_row = "=".repeat(100);
+        assert!(content.contains(&expected_row));
+    }
+
+    #[test]
+    fn contains_a_header_for_extra_attributes_when_configured() {
+        let (_tempdir, file_entries, directories) = setup_test();
+        let command = FormattingCommand::new(true, 100, file_entries, directories);
+        let content = generate_textual_display(command).unwrap();
+        assert!(content.starts_with("Name"));
+        assert!(content.contains("Date Created"));
+        assert!(content.contains("Date Modified"));
+        assert!(content.contains("Permissions"));
+    }
+
+    #[test]
+    fn does_not_contain_ext_attrs_headers_when_not_set() {
+        let (_tempdir, file_entries, directories) = setup_test();
+        let command = FormattingCommand::new(false, 400, file_entries, directories);
+        let contents = generate_textual_display(command).unwrap();
+        assert!(!contents.contains("Date Created"));
+        assert!(!contents.contains("Date Modified"));
+        assert!(!contents.contains("Permissions"));
+    }
+
+    #[test]
+    fn file_names_shortened_for_small_terminals_when_ext_attr_set() {
+        let (_temp_dir, file_1_full_path, compressed_width, files, directories) =
+            setup_long_name_test();
+        let command = FormattingCommand::new(true, compressed_width, files, directories);
+        let contents = generate_textual_display(command).unwrap();
+        let lines_of_content: Vec<&str> = contents.split('\n').collect();
+        let first_file_line = lines_of_content.get(2).unwrap();
+        let second_file_line = lines_of_content.get(3).unwrap();
+        let target_line = if first_file_line.contains("very_long") {
+            first_file_line
+        } else {
+            second_file_line
+        };
+        assert_eq!(target_line.len(), compressed_width);
+        assert!(!target_line.contains(file_1_full_path.as_str()));
+        let expected_content_chars: Vec<&str> = file_1_full_path
+            .graphemes(true)
+            .take(compressed_width - RESERVED_LENGTH)
+            .collect();
+        let expected_content = expected_content_chars.join("");
+        assert!(target_line.contains(&expected_content));
+    }
+
+    fn setup_long_name_test() -> (TempDir, String, usize, Vec<DirEntry>, Vec<DirEntry>) {
+        let long_file_name =
+            "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(FILE_1_NAME);
+        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
+            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
+            let suffix = "0".repeat(missing_graphmes);
+            suffix + long_file_name
+        } else {
+            long_file_name.to_string()
+        };
+        let file_2 = temp_dir.path().join(long_file_name);
+        let extra_dir = temp_dir.path().join("other");
+        File::create(&file_1).unwrap();
+        File::create(&file_2).unwrap();
+        fs::create_dir(&extra_dir).unwrap();
+        let dir_read = fs::read_dir(temp_dir.path()).unwrap();
+        let (files, directories) = dir_read
+            .filter_map(|entry| entry.ok())
+            .partition(|entry| entry.metadata().unwrap().is_file());
+        let file_2_full_path = file_2.to_str().unwrap().to_string();
+        let compressed_width = file_2_full_path.graphemes(true).count(); //so always file path is smaller that console
+
+        (
+            temp_dir,
+            file_2_full_path,
+            compressed_width,
+            files,
+            directories,
+        )
+    }
+
+    #[test]
+    fn there_is_always_space_between_fields() {
+        let (_temp_dir, _file_1_full_path, compressed_width, files, directories) =
+            setup_long_name_test();
+        let command = FormattingCommand::new(true, compressed_width, files, directories);
+        let contents = generate_textual_display(command).unwrap();
+        let lines_of_content: Vec<&str> = contents.split('\n').collect();
+        let first_file_line = lines_of_content.get(2).unwrap();
+        let second_file_line = lines_of_content.get(3).unwrap();
+        let target_line = if first_file_line.contains("very_long") {
+            first_file_line
+        } else {
+            second_file_line
+        };
+        let n_space_sep_components = target_line.split_ascii_whitespace().count();
+        // space between icon and name, name and datec, datec and timec, timec and perm, perm and datem, datem and timem
+        assert_eq!(n_space_sep_components, 7);
+    }
+    #[test]
+    fn contents_should_align_to_columns() {
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(FILE_1_NAME);
+        let file_2 = temp_dir.path().join(FILE_2_NAME);
+        let extra_dir = temp_dir.path().join("other");
+        File::create(&file_1).unwrap();
+        File::create(&file_2).unwrap();
+        fs::create_dir(&extra_dir).unwrap();
+        let dir_read = fs::read_dir(temp_dir.path()).unwrap();
+        let (files, directories) = dir_read
+            .filter_map(|entry| entry.ok())
+            .partition(|entry| entry.metadata().unwrap().is_file());
+        let command = FormattingCommand::new(true, 200, files, directories);
+        let contents = generate_textual_display(command).unwrap();
+
+        let lines: Vec<&str> = contents.split('\n').collect();
+        let title_line = lines[0];
+        let title_line_words: Vec<&str> = title_line.split("Date").collect();
+        let file_name_header = title_line_words[0];
+        let file_name_line = lines
+            .into_iter()
+            .find(|line| line.contains("file_1"))
+            .unwrap();
+        let expected_file_1_created = file_1.metadata().unwrap().created().unwrap();
+        let expected_date_str = crate::tests::calc_expected_date_string(&expected_file_1_created);
+        let file_name_line_sections: Vec<&str> =
+            file_name_line.split(expected_date_str.as_str()).collect();
+        let file_name_column = file_name_line_sections[0];
+        println!("{}", file_name_header);
+        println!("{}", file_name_column);
+        assert_eq!(
+            file_name_header.graphemes(true).count(),
+            file_name_column.graphemes(true).count() + 1 // for extra space
+        )
+    }
+
+    #[test]
+    fn paths_should_pad_to_max_length() {
+        let long_file_name =
+            "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(FILE_1_NAME);
+        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
+            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
+            let suffix = "0".repeat(missing_graphmes);
+            suffix + long_file_name
+        } else {
+            long_file_name.to_string()
+        };
+        let file_2 = temp_dir.path().join(long_file_name);
+        let extra_dir = temp_dir.path().join("other");
+        File::create(&file_1).unwrap();
+        File::create(&file_2).unwrap();
+        fs::create_dir(&extra_dir).unwrap();
+        let dir_read = fs::read_dir(temp_dir.path()).unwrap();
+        let (files, directories) = dir_read
+            .filter_map(|entry| entry.ok())
+            .partition(|entry| entry.metadata().unwrap().is_file());
+        let file_2_full_path = file_2.to_str().unwrap().to_string();
+        let compressed_width = file_2_full_path.graphemes(true).count(); //so always file path is smaller that console
+        let max_name_width = file_2_full_path.graphemes(true).count();
+        let always_sufficient_length = max_name_width + 70; //so always file path is smaller that console
+        let command = FormattingCommand::new(true, always_sufficient_length, files, directories);
+        let contents = generate_textual_display(command).unwrap();
+
+        let contents_as_lines: Vec<&str> = contents.split('\n').collect();
+        let first_path_line = contents_as_lines
+            .iter()
+            .find(|line| line.contains("very_long_filename"))
+            .unwrap();
+        let second_path_line = contents_as_lines
+            .iter()
+            .find(|line| line.contains(FILE_1_NAME))
+            .unwrap();
+        assert_eq!(first_path_line.len(), second_path_line.len());
+        let expected_file_2_created = file_2.metadata().unwrap().created().unwrap();
+        let expected_date_time_str = calc_expected_date_string(&expected_file_2_created);
+        let expected_date_components: Vec<&str> =
+            expected_date_time_str.split_whitespace().collect();
+        let expected_date_str = expected_date_components[0];
+        assert!(second_path_line.contains(expected_date_str));
+        let file_2_parts: Vec<&str> = second_path_line.split(expected_date_str).collect();
+        let file_1_parts: Vec<&str> = first_path_line.split(expected_date_str).collect();
+        assert_eq!(
+            file_2_parts[0].graphemes(true).count(),
+            file_1_parts[0].graphemes(true).count()
         );
     }
 }

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -1,57 +1,264 @@
-use crate::{FileEntryParsingError, FLOPPY, FOLDER, RESERVED_LENGTH};
-use std::fs::DirEntry;
+use crate::FileEntryParsingError::UnableToCalculatePathLengths;
+use crate::TimeOptions::{Created, Modified};
+use crate::{FileEntryParsingError, TimeOptions};
+use chrono::{DateTime, Utc};
+use std::fs::{DirEntry, Metadata};
+use std::ops::Add;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::{Duration, UNIX_EPOCH};
+use unicode_segmentation::UnicodeSegmentation;
 
 pub struct FormattingCommand {
     extended_attr: bool,
     width: usize,
     files: Vec<DirEntry>,
-    longest: usize,
+    directories: Vec<DirEntry>,
 }
 
 impl FormattingCommand {
-    pub fn new(extended_attr: bool, width: usize, files: Vec<DirEntry>, longest: usize) -> Self {
+    pub fn new(
+        extended_attr: bool,
+        width: usize,
+        files: Vec<DirEntry>,
+        directories: Vec<DirEntry>,
+    ) -> Self {
         FormattingCommand {
             extended_attr,
             width,
             files,
-            longest,
+            directories,
         }
     }
 }
 
 pub fn generate_textual_display(
     command: FormattingCommand,
-    directories: Vec<DirEntry>,
 ) -> Result<String, FileEntryParsingError> {
-    let mut header_row = if command.extended_attr && command.width > 80 {
-        crate::create_extended_attr_header(command.width, command.longest)
+    let boxed_command = Rc::new(command);
+    let command_ref = boxed_command.as_ref();
+    let Some(longest) = analyse_longest(boxed_command.as_ref()) else {
+        return Err(UnableToCalculatePathLengths);
+    };
+    let mut header_row = if command_ref.extended_attr && command_ref.width > 80 {
+        create_extended_attr_header(command_ref.width, longest)
     } else {
         vec![
             String::from("Name:"),
-            String::from("=").repeat(command.width),
+            String::from("=").repeat(command_ref.width),
         ]
     };
-    let mut string_list_of_files = orchestrate_formatting(command)?;
-    let mut string_list_of_dirs = crate::format_each_entry(directories, FOLDER)?;
+    let mut string_list_of_files = orchestrate_formatting(boxed_command.as_ref(), longest)?;
+    let mut string_list_of_dirs = format_each_entry(&command_ref.directories, FOLDER)?;
     header_row.append(&mut string_list_of_files);
     header_row.append(&mut string_list_of_dirs);
     Ok(header_row.join("\n"))
 }
 
 fn orchestrate_formatting(
-    command: FormattingCommand,
+    command: &FormattingCommand,
+    longest: usize,
 ) -> Result<Vec<String>, FileEntryParsingError> {
     Ok(if command.extended_attr && command.width > 80 {
         let available_filename_space = command.width - RESERVED_LENGTH;
-        let file_name_target_length = if available_filename_space > command.longest {
-            command.longest
+        let file_name_target_length = if available_filename_space > longest {
+            longest
         } else {
             available_filename_space
         };
-        crate::format_each_ext_attr_entry(&command.files, file_name_target_length)?
+        format_each_ext_attr_entry(&command.files, file_name_target_length)?
     } else if command.extended_attr && command.width <= 80 {
         panic!("requires minimum console width of 80");
     } else {
-        crate::format_each_entry(command.files, FLOPPY)?
+        format_each_entry(&command.files, FLOPPY)?
     })
+}
+
+pub const FLOPPY: &str = "\u{1F4BE}";
+const FOLDER: &str = "\u{1F4C1}";
+pub const RESERVED_LENGTH: usize = 66;
+
+pub const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S%.3f";
+
+fn create_extended_attr_header(width: usize, longest: usize) -> Vec<String> {
+    let date_created_heading = create_heading_of_width(24usize, "Date Created");
+    let date_modified_heading = create_heading_of_width(24usize, "Date Modified");
+    let permissions_heading = create_heading_of_width(13usize, "Permissions");
+    let remaining_width = if longest + 4 <= width - 60 {
+        longest + 4
+    } else {
+        width - 60
+    };
+    let name_heading = create_heading_of_width(remaining_width, "Name");
+    let header = "".to_string();
+    vec![
+        header
+            + name_heading.as_str()
+            + date_created_heading.as_str()
+            + permissions_heading.as_str()
+            + date_modified_heading.as_str(),
+        String::from("=").repeat(width),
+    ]
+}
+
+fn create_heading_of_width(head_width: usize, name: &str) -> String {
+    name.to_string().add(
+        " ".repeat(head_width - name.graphemes(true).count())
+            .as_str(),
+    )
+}
+
+fn format_each_ext_attr_entry(
+    files: &[DirEntry],
+    max_file_name_width: usize,
+) -> Result<Vec<String>, FileEntryParsingError> {
+    files
+        .iter()
+        .map(|dir| format_file_entry_with_ext_attr(dir, max_file_name_width))
+        .collect()
+}
+
+fn format_file_entry_with_ext_attr(
+    dir: &DirEntry,
+    allowed_width: usize,
+) -> Result<String, FileEntryParsingError> {
+    let file_name_as_path = dir.path();
+    let file_name = match file_name_as_path.to_str() {
+        Some(file_name) => set_file_name_length(allowed_width, file_name),
+        None => return Err(FileEntryParsingError::FileNameInvalidUnicode),
+    };
+    let meta_data = match dir.metadata() {
+        Ok(meta) => meta,
+        Err(error) => {
+            return Err(FileEntryParsingError::MissingMetaDataError {
+                original_error: error.kind(),
+            })
+        }
+    };
+    let date_created = get_formatted_date(&meta_data, Created);
+    let permissions = if meta_data.permissions().readonly() {
+        "read only   "
+    } else {
+        "writable    "
+    };
+    let date_modified = get_formatted_date(&meta_data, Modified);
+    Ok([
+        FLOPPY,
+        file_name.as_str(),
+        &date_created,
+        permissions,
+        &date_modified,
+    ]
+    .join(" "))
+}
+
+fn set_file_name_length(allowed_width: usize, file_name: &str) -> String {
+    if file_name.graphemes(true).count() >= allowed_width {
+        let file_name_strs = file_name
+            .graphemes(true)
+            .take(allowed_width)
+            .collect::<Vec<&str>>();
+        file_name_strs.join("")
+    } else {
+        let spacer_length = allowed_width - file_name.len();
+        let spacer = " ".repeat(spacer_length);
+        file_name.to_string() + spacer.as_str()
+    }
+}
+
+fn get_formatted_date(meta_data: &Metadata, options: TimeOptions) -> String {
+    let since_epoch = match options {
+        Created => meta_data
+            .created()
+            .expect(
+                "Not anticipated to run on systems that do not implement date created for files",
+            )
+            .duration_since(UNIX_EPOCH)
+            .expect("Clock may have gone backwards"),
+        TimeOptions::Modified => meta_data
+            .modified()
+            .expect(
+                "Not anticipated to run on systems that do not implement date modified for files",
+            )
+            .duration_since(UNIX_EPOCH)
+            .expect("Clock may have gone backwards"),
+    };
+    format_date(since_epoch)
+}
+
+fn format_date(since_epoch: Duration) -> String {
+    DateTime::<Utc>::from_timestamp(
+        since_epoch.as_secs() as i64,
+        since_epoch.subsec_nanos(),
+    )
+      .expect(
+          "An invalid timestamp was provided, given this is from the system this should not happen",
+      )
+      .format(DATE_FORMAT)
+      .to_string()
+}
+
+fn format_each_entry(
+    dir_entries: &Vec<DirEntry>,
+    icon: &str,
+) -> Result<Vec<String>, FileEntryParsingError> {
+    Ok(dir_entries
+        .iter()
+        .filter_map(|entry| crate::convert_dir_entry_to_str(entry).ok())
+        .map(|file_name| icon.to_owned() + " " + &file_name)
+        .collect())
+}
+
+fn analyse_longest(command: &FormattingCommand) -> Option<usize> {
+    let joined = [&command.files, &command.directories];
+    let full_list: Vec<&DirEntry> = joined.iter().flat_map(|vec| vec.iter()).collect();
+    full_list
+        .into_iter()
+        .map(|dir_entry: &DirEntry| dir_entry.path())
+        .map(|path: PathBuf| {
+            let path_as_str_option = path.to_str();
+            let path_as_str = path_as_str_option.unwrap_or("");
+            String::from(path_as_str)
+        })
+        .map(|stringy| stringy.len())
+        .max()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::output_formatting::{generate_textual_display, FormattingCommand};
+    use std::fs;
+    use std::fs::{DirEntry, File};
+    use tempfile::tempdir;
+
+    fn setup_test() -> (Vec<DirEntry>, Vec<DirEntry>) {
+        const FILE_1_NAME: &str = "file_1.txt";
+        const FILE_2_NAME: &str = "file_2.txt";
+
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(FILE_1_NAME);
+        let file_2 = temp_dir.path().join(FILE_2_NAME);
+        let extra_dir = temp_dir.path().join("other");
+        File::create(&file_1).unwrap();
+        File::create(&file_2).unwrap();
+        fs::create_dir(&extra_dir).unwrap();
+        let dir_read = fs::read_dir(temp_dir.path()).unwrap();
+
+        dir_read
+            .filter_map(|entry| entry.ok())
+            .partition(|entry| entry.metadata().unwrap().is_file())
+    }
+
+    #[test]
+    fn non_extended_output_contains_header_row() {
+        let (file_entries, directories) = setup_test();
+        let command = FormattingCommand::new(false, 200, file_entries, directories);
+        let content = generate_textual_display(command).unwrap();
+        let lines_of_content = content.split('\n').collect::<Vec<&str>>();
+        let header_row = lines_of_content.get(0).unwrap();
+        assert!(header_row.starts_with("Name"));
+        assert!(!header_row.contains("Date Created"));
+        assert!(!header_row.contains("Date Modified"));
+        assert!(!header_row.contains("Permissions"));
+    }
 }

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -481,8 +481,28 @@ mod tests {
 
     #[test]
     fn spaces_out_columns() {
-        let (_tempdir, file_entries, directories) = setup_test();
-        let command = FormattingCommand::new(true, 100, file_entries, directories);
+        // let (_tempdir, file_entries, directories) = setup_test();
+        let long_file_name =
+            "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
+        let temp_dir = tempdir().unwrap();
+        let file_1 = temp_dir.path().join(FILE_1_NAME);
+        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
+            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
+            let suffix = "0".repeat(missing_graphmes);
+            suffix + long_file_name
+        } else {
+            long_file_name.to_string()
+        };
+        let file_2 = temp_dir.path().join(long_file_name);
+        let extra_dir = temp_dir.path().join("other");
+        File::create(&file_1).unwrap();
+        File::create(&file_2).unwrap();
+        fs::create_dir(&extra_dir).unwrap();
+        let dir_read = fs::read_dir(temp_dir.path()).unwrap();
+        let (files, directories) = dir_read
+            .filter_map(|entry| entry.ok())
+            .partition(|entry| entry.metadata().unwrap().is_file());
+        let command = FormattingCommand::new(true, 100, files, directories);
         let contents = generate_textual_display(command).unwrap();
         // Date Created and Date Modified = 24 each, rest Name
         let expected_header = "Name                                    Date Created            Permissions  Date Modified           ";

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -5,7 +5,6 @@ use chrono::{DateTime, Utc};
 use std::fs::{DirEntry, Metadata};
 use std::ops::Add;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::time::{Duration, UNIX_EPOCH};
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -237,6 +237,7 @@ mod tests {
     use crate::tests::calc_expected_date_string;
     use std::fs;
     use std::fs::{DirEntry, File};
+    use std::path::PathBuf;
     use tempfile::{tempdir, TempDir};
     use unicode_segmentation::UnicodeSegmentation;
 
@@ -344,13 +345,7 @@ mod tests {
             "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
         let temp_dir = tempdir().unwrap();
         let file_1 = temp_dir.path().join(FILE_1_NAME);
-        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
-            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
-            let suffix = "0".repeat(missing_graphmes);
-            suffix + long_file_name
-        } else {
-            long_file_name.to_string()
-        };
+        let long_file_name = validate_file_length(long_file_name, &file_1);
         let file_2 = temp_dir.path().join(long_file_name);
         let extra_dir = temp_dir.path().join("other");
         File::create(&file_1).unwrap();
@@ -362,7 +357,6 @@ mod tests {
             .partition(|entry| entry.metadata().unwrap().is_file());
         let file_2_full_path = file_2.to_str().unwrap().to_string();
         let compressed_width = file_2_full_path.graphemes(true).count(); //so always file path is smaller that console
-
         (
             temp_dir,
             file_2_full_path,
@@ -370,6 +364,17 @@ mod tests {
             files,
             directories,
         )
+    }
+
+    fn validate_file_length(long_file_name: &str, file_1: &PathBuf) -> String {
+        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
+            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
+            let suffix = "0".repeat(missing_graphmes);
+            suffix + long_file_name
+        } else {
+            long_file_name.to_string()
+        };
+        long_file_name
     }
 
     #[test]
@@ -433,13 +438,7 @@ mod tests {
             "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
         let temp_dir = tempdir().unwrap();
         let file_1 = temp_dir.path().join(FILE_1_NAME);
-        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
-            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
-            let suffix = "0".repeat(missing_graphmes);
-            suffix + long_file_name
-        } else {
-            long_file_name.to_string()
-        };
+        let long_file_name = validate_file_length(long_file_name, &file_1);
         let file_2 = temp_dir.path().join(long_file_name);
         let extra_dir = temp_dir.path().join("other");
         File::create(&file_1).unwrap();
@@ -486,13 +485,7 @@ mod tests {
             "very_long_filename_to_check_for_shortening_of_filename_on_small_consoles.txt";
         let temp_dir = tempdir().unwrap();
         let file_1 = temp_dir.path().join(FILE_1_NAME);
-        let long_file_name = if file_1.to_str().unwrap().len() < 80 {
-            let missing_graphmes = 80 - file_1.to_str().unwrap().len();
-            let suffix = "0".repeat(missing_graphmes);
-            suffix + long_file_name
-        } else {
-            long_file_name.to_string()
-        };
+        let long_file_name = validate_file_length(long_file_name, &file_1);
         let file_2 = temp_dir.path().join(long_file_name);
         let extra_dir = temp_dir.path().join("other");
         File::create(&file_1).unwrap();

--- a/src/output_formatting.rs
+++ b/src/output_formatting.rs
@@ -68,7 +68,7 @@ fn analyse_longest(command: &FormattingCommand) -> Option<usize> {
             let path_as_str = path_as_str_option.unwrap_or("");
             String::from(path_as_str)
         })
-        .map(|stringy| stringy.len())
+        .map(|stringy| stringy.graphemes(true).count())
         .max()
 }
 


### PR DESCRIPTION
Add option to view file metadata with -l
Separate output formatting from file handling logic by moving into another module
Move tests for related output formatting to the output formatting module and refactor to generally make them a little simpler to set up